### PR TITLE
postgresql bumped from 9.6.23 to 9.6.24 to fix cve issue

### DIFF
--- a/plan.sh
+++ b/plan.sh
@@ -1,13 +1,13 @@
 # shellcheck disable=SC2164
 pkg_name=postgresql
-pkg_version=9.6.23
+pkg_version=9.6.24
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="PostgreSQL is a powerful, open source object-relational database system."
 pkg_upstream_url="https://www.postgresql.org/"
 pkg_license=('PostgreSQL')
 pkg_source="https://ftp.postgresql.org/pub/source/v${pkg_version}/${pkg_name}-${pkg_version}.tar.bz2"
-pkg_shasum=a849f798401ab8c6dfa653ebbcd853b43f2200b4e3bc1ea3cb5bec9a691947b9
+pkg_shasum=aeb7a196be3ebed1a7476ef565f39722187c108dd47da7489be9c4fcae982ace
 
 pkg_deps=(
   core/bash


### PR DESCRIPTION
Issue: https://chefio.atlassian.net/jira/software/c/projects/HABP/boards/378?modal=detail&selectedIssue=HABP-102
Signed-off-by: Sangameshwar Mandakanalli <smandaka@progress.com>